### PR TITLE
Issue 21/render triangle

### DIFF
--- a/src/device.cpp
+++ b/src/device.cpp
@@ -312,6 +312,7 @@ void Device::createCommandPool() {
       findQueueFamilies(this->physicalDevice);
 
   vk::CommandPoolCreateInfo createInfo = {};
+  createInfo.flags = vk::CommandPoolCreateFlagBits::eResetCommandBuffer;
   createInfo.queueFamilyIndex = queueFamilyIndices.graphicsFamily.value();
 
   try {

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -1,16 +1,66 @@
 #include "engine.hpp"
 
+#include "util/logger.hpp"
+
 namespace hep {
 
 Engine::Engine()
     : window{WINDOW_WIDTH, WINDOW_HEIGHT},
       device{this->window},
-      renderer{this->window, this->device} {}
+      renderer{this->window, this->device},
+      pipeline{device} {
+  createPipelineLayout();
+  createPipeline(this->renderer.getSwapChainRenderPass());
+}
 
-Engine::~Engine() {}
+Engine::~Engine() {
+  log::verbose("destroyed vk::PipelineLayout");
+  this->device.get()->destroyPipelineLayout(this->pipelineLayout);
+}
 
 void Engine::run() {
-  while (!this->window.shouldClose()) { glfwPollEvents(); }
+  while (!this->window.shouldClose()) {
+    glfwPollEvents();
+
+    vk::CommandBuffer commandBuffer = this->renderer.beginFrame();
+    if (commandBuffer != nullptr) {
+      this->renderer.beginSwapChainRenderPass(commandBuffer);
+
+      this->pipeline.bind(commandBuffer);
+      commandBuffer.draw(3, 1, 0, 0);
+
+      this->renderer.endSwapChainRenderPass(commandBuffer);
+      this->renderer.endFrame();
+    }
+  }
+
+  this->device.get()->waitIdle();
 }
+
+void Engine::createPipelineLayout() {
+  vk::PipelineLayoutCreateInfo pipelineLayoutInfo = {};
+  pipelineLayoutInfo.setLayoutCount = 0;
+  pipelineLayoutInfo.pushConstantRangeCount = 0;
+
+  try {
+    this->pipelineLayout =
+        this->device.get()->createPipelineLayout(pipelineLayoutInfo);
+    log::verbose("created vk::PipelineLayout");
+  } catch (const vk::SystemError& err) {
+    log::fatal("failed to create vk::PipelineLayout");
+    throw std::runtime_error("failed to create vk::PipelineLayout");
+  }
+}
+
+void Engine::createPipeline(vk::RenderPass renderPass) {
+  assert(pipelineLayout != nullptr &&
+         "Cannot create pipeline before pipeline layout");
+
+  this->pipeline.create("shaders/triangle.vert.spv",
+                        "shaders/triangle.frag.spv", this->pipelineLayout,
+                        renderPass);
+}
+
+void Engine::render() {}
 
 }  // namespace hep

--- a/src/engine.hpp
+++ b/src/engine.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "device.hpp"
+#include "pipeline.hpp"
 #include "renderer.hpp"
 #include "window.hpp"
 
@@ -20,9 +21,15 @@ class Engine {
   void run();
 
  private:
+  void createPipelineLayout();
+  void createPipeline(vk::RenderPass renderPass);
+  void render();
+
   Window window;
   Device device;
   Renderer renderer;
+  Pipeline pipeline;
+  vk::PipelineLayout pipelineLayout;
 };
 
 }  // namespace hep

--- a/src/pipeline.hpp
+++ b/src/pipeline.hpp
@@ -13,7 +13,7 @@ struct PipelineConfig {
   PipelineConfig() = default;
   PipelineConfig(const PipelineConfig&) = delete;
   PipelineConfig& operator=(const PipelineConfig&) = delete;
-  
+
   std::vector<vk::VertexInputBindingDescription> bindingDescriptions{};
   std::vector<vk::VertexInputAttributeDescription> attributeDescriptions{};
   vk::PipelineInputAssemblyStateCreateInfo inputAssemblyInfo;
@@ -40,7 +40,7 @@ class Pipeline {
 
   void create(const std::string& vertexShaderFilename,
               const std::string& fragmentShaderFilename,
-              vk::RenderPass renderPass);
+              vk::PipelineLayout pipelineLayout, vk::RenderPass renderPass);
 
   void bind(vk::CommandBuffer commandBuffer);
 
@@ -51,7 +51,6 @@ class Pipeline {
   Device& device;
   PipelineConfig config;
   vk::Pipeline graphicsPipeline;
-  vk::PipelineLayout pipelineLayout;
 };
 
 }  // namespace hep

--- a/src/renderer.cpp
+++ b/src/renderer.cpp
@@ -5,84 +5,129 @@
 namespace hep {
 
 Renderer::Renderer(Window& window, Device& device)
-    : window{window},
-      device{device},
-      swapchain{device, window.getExtent()},
-      pipeline{device} {
-  this->pipeline.create("shaders/triangle.vert.spv",
-                        "shaders/triangle.frag.spv",
-                        this->swapchain.getRenderPass());
+    : window{window}, device{device}, swapchain{device, window.getExtent()} {
   createCommandBuffers();
 }
 
-Renderer::~Renderer() { freeCommandBuffers(); }
+Renderer::~Renderer() {}
+
+vk::CommandBuffer Renderer::beginFrame() {
+  assert(!this->isFrameStarted &&
+         "Can't call beginFrame while already in progress");
+
+  vk::Result result = this->swapchain.acquireNextImage(&currentImageIndex);
+  if (result == vk::Result::eErrorOutOfDateKHR) {
+    throw std::runtime_error("swap chain KHR out of date");
+  }
+
+  if (result != vk::Result::eSuccess && result != vk::Result::eSuboptimalKHR) {
+    throw std::runtime_error("failed to acquire swap chain image");
+  }
+
+  this->isFrameStarted = true;
+
+  vk::CommandBuffer commandBuffer = getCurrentCommandBuffer();
+
+  vk::CommandBufferBeginInfo beginInfo = {};
+  beginInfo.flags = vk::CommandBufferUsageFlagBits::eSimultaneousUse;
+
+  try {
+    commandBuffer.begin(beginInfo);
+  } catch (const vk::SystemError& err) {
+    log::fatal("failed to begin recording command buffer");
+    throw std::runtime_error("failed to begin recording command buffer");
+  }
+
+  return commandBuffer;
+}
+
+void Renderer::endFrame() {
+  assert(isFrameStarted &&
+         "Can't call endFrame while frame is not in progress");
+
+  vk::CommandBuffer commandBuffer = getCurrentCommandBuffer();
+  if (!commandBuffer) {
+    log::fatal("Invalid command buffer");
+    throw std::runtime_error("Invalid command buffer");
+  }
+
+  try {
+    commandBuffer.end();
+  } catch (const vk::SystemError& err) {
+    log::fatal("failed to record command buffer");
+    throw std::runtime_error("failed to record command buffer");
+  }
+
+  vk::Result result =
+      this->swapchain.submitCommandBuffers(&commandBuffer, &currentImageIndex);
+
+  if (result == vk::Result::eErrorOutOfDateKHR ||
+      result == vk::Result::eSuboptimalKHR) {
+    // window size was changed, or swapchain out of date, recreate swapChain
+    throw std::runtime_error("swapchain out of date");
+  } else if (result != vk::Result::eSuccess) {
+    throw std::runtime_error("failed to present swap chain image");
+  }
+
+  isFrameStarted = false;
+  currentFrameIndex = (currentFrameIndex + 1) % Swapchain::MAX_FRAMES_IN_FLIGHT;
+}
+
+void Renderer::beginSwapChainRenderPass(vk::CommandBuffer commandBuffer) {
+  assert(isFrameStarted &&
+         "Can't call beginSwapChainRenderPass if frame is not in progress");
+  assert(commandBuffer == getCurrentCommandBuffer() &&
+         "Can't begin render pass on command buffer from a different frame");
+
+  vk::RenderPassBeginInfo renderPassInfo = {};
+  renderPassInfo.renderPass = this->swapchain.getRenderPass();
+  renderPassInfo.framebuffer =
+      this->swapchain.getFrameBuffer(this->currentImageIndex);
+  renderPassInfo.renderArea.offset = vk::Offset2D{0, 0};
+  renderPassInfo.renderArea.extent = this->swapchain.getExtent();
+
+  vk::ClearValue clearColor = {std::array<float, 4>{0.0f, 0.0f, 0.0f, 1.0f}};
+  renderPassInfo.clearValueCount = 1;
+  renderPassInfo.pClearValues = &clearColor;
+
+  commandBuffer.beginRenderPass(&renderPassInfo, vk::SubpassContents::eInline);
+
+  vk::Viewport viewport{0.0f,
+                        0.0f,
+                        static_cast<float>(this->swapchain.width()),
+                        static_cast<float>(this->swapchain.height()),
+                        0.0f,
+                        1.0f};
+  vk::Rect2D scissor{{0, 0}, this->swapchain.getExtent()};
+
+  commandBuffer.setViewport(0, 1, &viewport);
+  commandBuffer.setScissor(0, 1, &scissor);
+}
+
+void Renderer::endSwapChainRenderPass(vk::CommandBuffer commandBuffer) {
+  assert(isFrameStarted &&
+         "Can't call endSwapChainRenderPass if frame is not in progress");
+  assert(commandBuffer == getCurrentCommandBuffer() &&
+         "Can't end render pass on command buffer from a different frame");
+  commandBuffer.endRenderPass();
+}
 
 void Renderer::createCommandBuffers() {
   this->commandBuffers.resize(Swapchain::MAX_FRAMES_IN_FLIGHT);
 
   vk::CommandBufferAllocateInfo allocInfo = {};
-  allocInfo.commandPool = this->device.getCommandPool();
   allocInfo.level = vk::CommandBufferLevel::ePrimary;
+  allocInfo.commandPool = this->device.getCommandPool();
   allocInfo.commandBufferCount = static_cast<u32>(this->commandBuffers.size());
 
   try {
     this->commandBuffers =
         this->device.get()->allocateCommandBuffers(allocInfo);
+    log::verbose("created all commandBuffers");
   } catch (const vk::SystemError& err) {
     log::fatal("failed to allocate command buffers");
     throw std::runtime_error("failed to allocate command buffers");
   }
-
-  for (size_t i = 0; i < this->commandBuffers.size(); i++) {
-    vk::CommandBufferBeginInfo beginInfo = {};
-    beginInfo.flags = vk::CommandBufferUsageFlagBits::eSimultaneousUse;
-
-    try {
-      this->commandBuffers[i].begin(beginInfo);
-    } catch (const vk::SystemError& err) {
-      log::fatal("failed to begin recording command buffer");
-      throw std::runtime_error("failed to begin recording command buffer");
-    }
-
-    vk::RenderPassBeginInfo renderPassInfo = {};
-    renderPassInfo.renderPass = this->swapchain.getRenderPass();
-    renderPassInfo.framebuffer = this->swapchain.getFrameBuffer(i);
-    renderPassInfo.renderArea.offset = vk::Offset2D{0, 0};
-    renderPassInfo.renderArea.extent = this->swapchain.getExtent();
-
-    vk::ClearValue clearColor = {std::array<float, 4>{0.0f, 0.0f, 0.0f, 1.0f}};
-    renderPassInfo.clearValueCount = 1;
-    renderPassInfo.pClearValues = &clearColor;
-
-    this->commandBuffers[i].beginRenderPass(renderPassInfo,
-                                            vk::SubpassContents::eInline);
-
-    vk::Viewport viewport{
-        0.0,  0.0, this->swapchain.width(), this->swapchain.height(),
-        0.0f, 1.0f};
-    vk::Rect2D scissor{{0, 0}, this->swapchain.getExtent()};
-
-    this->commandBuffers.at(i).setViewport(0, 1, &viewport);
-    this->commandBuffers.at(i).setScissor(0, 1, &scissor);
-
-    // vkCmdSetViewport(commandBuffer, 0, 1, &viewport);
-    // vkCmdSetScissor(commandBuffer, 0, 1, &scissor);
-
-    this->pipeline.bind(this->commandBuffers.at(i));
-
-    this->commandBuffers[i].draw(3, 1, 0, 0);
-
-    this->commandBuffers[i].endRenderPass();
-
-    try {
-      this->commandBuffers[i].end();
-    } catch (const vk::SystemError& err) {
-      log::fatal("failed to record command buffer");
-      throw std::runtime_error("failed to record command buffer");
-    }
-  }
 }
-
-void Renderer::freeCommandBuffers() {}
 
 }  // namespace hep

--- a/src/renderer.hpp
+++ b/src/renderer.hpp
@@ -3,8 +3,8 @@
 #include <vulkan/vulkan.hpp>
 
 #include "device.hpp"
-#include "pipeline.hpp"
 #include "swapchain.hpp"
+#include "util/types.hpp"
 #include "window.hpp"
 
 namespace hep {
@@ -21,6 +21,17 @@ class Renderer {
     return this->swapchain.getRenderPass();
   }
 
+  vk::CommandBuffer getCurrentCommandBuffer() const {
+    assert(this->isFrameStarted &&
+           "Cannot get command buffer when frame not in progress");
+    return this->commandBuffers.at(currentFrameIndex);
+  }
+
+  vk::CommandBuffer beginFrame();
+  void endFrame();
+  void beginSwapChainRenderPass(vk::CommandBuffer commandBuffer);
+  void endSwapChainRenderPass(vk::CommandBuffer commandBuffer);
+
  private:
   void createCommandBuffers();
   void freeCommandBuffers();
@@ -30,8 +41,9 @@ class Renderer {
   Swapchain swapchain;
   std::vector<vk::CommandBuffer> commandBuffers;
 
-  // temp
-  Pipeline pipeline;
+  u32 currentImageIndex;
+  int currentFrameIndex = 0;
+  bool isFrameStarted = false;
 };
 
 }  // namespace hep

--- a/src/swapchain.hpp
+++ b/src/swapchain.hpp
@@ -10,7 +10,7 @@ namespace hep {
 
 class Swapchain {
  public:
-  static constexpr int MAX_FRAMES_IN_FLIGHT = 2;
+  static constexpr u32 MAX_FRAMES_IN_FLIGHT = 2;
 
   Swapchain(const Swapchain&) = delete;
   Swapchain& operator=(const Swapchain&) = delete;
@@ -23,25 +23,25 @@ class Swapchain {
   }
 
   vk::RenderPass getRenderPass() const { return this->renderPass; }
-
   vk::ImageView getImageView(int index) { return this->imageViews.at(index); }
-
   size_t imageCount() { return this->images.size(); }
-
   vk::Format getImageFormat() { return this->imageFormat; }
-
   VkExtent2D getExtent() { return this->extent; }
-
   u32 width() { return this->extent.width; }
-
   u32 height() { return this->extent.height; }
 
+  vk::Result acquireNextImage(u32* imageIndex);
+  vk::Result submitCommandBuffers(const vk::CommandBuffer* buffers,
+                                  u32* imageIndex);
+
  private:
+  void initialize();
   void setDefaultCreateInfo();
   void createSwapchain();
   void createImageViews();
   void createRenderPass();
   void createFramebuffers();
+  void createSyncObjects();
 
   vk::SurfaceFormatKHR chooseSurfaceFormat(
       const std::vector<vk::SurfaceFormatKHR>& availableFormats);
@@ -59,6 +59,13 @@ class Swapchain {
 
   vk::RenderPass renderPass;
   std::vector<vk::Framebuffer> framebuffers;
+
+  std::vector<vk::Semaphore> imageAvailableSemaphores;
+  std::vector<vk::Semaphore> renderFinishedSemaphores;
+  std::vector<vk::Fence> inFlightFences;
+  std::vector<vk::Fence> imagesInFlight;
+
+  size_t currentFrame = 0;
 };
 
 }  // namespace hep


### PR DESCRIPTION
resolves #21 

## Context

Finally, we can render out triangle. Note that this triangle is hard coded in the shaders.

## Implementation

- `renderer` functionality for recording to a command buffer
- `swapchain` functionality for submitting command buffer to graphics queue

## Screenshots

![triangle](https://github.com/user-attachments/assets/770840fc-381e-4a0c-8282-eaa3b5c5412e)
***figure 1** drawing a solid triangle*

## Testing Instructions

1. Build app via `make`
2. Run app via `./app.bin`
