### PR TITLE
Issue 46/staging buffer

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,4 +18,5 @@ TODO
 
 ## Testing Instructions
 
-TODO
+1. Build engine via `mkdir build && cd build && cmake .. && make`
+2. Run app via `cd build/ && ./app.bin`

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -27,5 +27,7 @@
   "C_Cpp.clang_format_fallbackStyle": "{ BasedOnStyle: Google, AllowShortBlocksOnASingleLine: Always }",
   "C_Cpp.default.compileCommands": "${workspaceFolder}/build/compile_commands.json",
   "files.autoSave": "off",
-  "files.associations": {}
+  "files.associations": {
+    "stdexcept": "cpp"
+  }
 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,38 @@ add_subdirectory(external/glm)
 # Store source files
 file(GLOB_RECURSE SRC_FILES src/*.cpp)
 
+# Store shader files and define build rules
+find_program(GLSL_VALIDATOR glslangValidator HINTS 
+${Vulkan_GLSLANG_VALIDATOR_EXECUTABLE}
+/usr/bin 
+/usr/local/bin 
+${VULKAN_SDK_PATH}/Bin
+${VULKAN_SDK_PATH}/Bin32
+)
+file(GLOB_RECURSE GLSL_SOURCE_FILES
+  "${PROJECT_SOURCE_DIR}/shaders/*.frag"
+  "${PROJECT_SOURCE_DIR}/shaders/*.vert"
+)
+
+set(SHADER_DIR shaders)
+set(SHADER_OUTPUT_DIR ${CMAKE_BINARY_DIR}/${SHADER_DIR})
+
+foreach(GLSL ${GLSL_SOURCE_FILES})
+  get_filename_component(FILE_NAME ${GLSL} NAME)
+  set(SPIRV "${SHADER_OUTPUT_DIR}/${FILE_NAME}.spv")
+  add_custom_command(
+    OUTPUT ${SPIRV}
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${SHADER_OUTPUT_DIR}
+    COMMAND ${GLSL_VALIDATOR} -V ${GLSL} -o ${SPIRV}
+    DEPENDS ${GLSL})
+  list(APPEND SPIRV_BINARY_FILES ${SPIRV})
+endforeach(GLSL)
+
+add_custom_target(
+  ${SHADER_DIR}
+  DEPENDS ${SPIRV_BINARY_FILES}
+)
+
 # Define Executable
 add_executable(${PROJECT_NAME} app.cpp ${SRC_FILES} ${SPIRV_SHADERS})
 
@@ -50,7 +82,7 @@ target_include_directories(${PROJECT_NAME}
   PUBLIC external/glfw/include
   PUBLIC external/glm/include
 )
-
+  
 target_link_libraries(${PROJECT_NAME}
   PRIVATE glfw
   PRIVATE glm
@@ -62,8 +94,10 @@ target_link_libraries(${PROJECT_NAME}
   PRIVATE Xrandr
   PRIVATE Xi
 )
-
+  
 set_target_properties(${PROJECT_NAME} PROPERTIES 
-  RUNTIME_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR} 
+  RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR} 
   OUTPUT_NAME app.bin
 )
+
+add_dependencies(${PROJECT_NAME} ${SHADER_DIR})

--- a/src/device.hpp
+++ b/src/device.hpp
@@ -65,6 +65,13 @@ class Device {
                     vk::MemoryPropertyFlags properties, vk::Buffer& buffer,
                     vk::DeviceMemory& bufferMemory);
 
+  vk::CommandBuffer beginSingleTimeCommands();
+
+  void endSingleTimeCommands(vk::CommandBuffer commandBuffer);
+
+  void copyBuffer(vk::Buffer sourceBuffer, vk::Buffer destinationBuffer,
+                  vk::DeviceSize size);
+
   void createImageWithInfo(const vk::ImageCreateInfo& imageInfo,
                            vk::MemoryPropertyFlags properties, vk::Image& image,
                            vk::DeviceMemory& imageMemory);

--- a/src/model.hpp
+++ b/src/model.hpp
@@ -42,6 +42,7 @@ class Model {
   void createVertexBuffers(const std::vector<Vertex>& vertices);
 
   Device& device;
+
   vk::Buffer vertexBuffer;
   vk::DeviceMemory vertexBufferMemory;
   u32 vertexCount;


### PR DESCRIPTION
resolves #46 

## Context

Buffers with device only memory is alot faster then buffers with coherent memory (between host and device)

## Testing Instructions

1. Build engine via `mkdir build && cd build && cmake .. && make`
2. Run app via `cd build/ && ./app.bin`
