### PR TITLE
Buiding project to shared object

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,4 +19,5 @@ TODO
 ## Testing Instructions
 
 1. Build engine via `mkdir build && cd build && cmake .. && make`
-2. Run app via `cd build/ && ./app.bin`
+2. Build testbed via `cd testbed/ && cmake . && make`
+3. Run testbed via `./testbed`

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -6,6 +6,7 @@
         "${workspaceFolder}/**",
         "${workspaceFolder}/external/glfw/include",
         "${workspaceFolder}/external/glm",
+        "${workspaceFolder}/include",
         "${workspaceFolder}/src"
       ],
       "defines": [],

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.30.0)
+cmake_minimum_required(VERSION 3.22.2)
 
 project(hephaestus VERSION 0.0.0)
 
@@ -15,6 +15,9 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 # if(CMAKE_BUILD_TYPE STREQUAL "release")
 #     add_definitions(-DNDEBUG)
 # endif()
+
+set(BUILD_SHARED_LIBS OFF CACHE BOOL "Build shared libraries" FORCE)
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static-libgcc -static-libstdc++")
 
 # Download git submodules
 find_package(Git QUIET)
@@ -36,8 +39,9 @@ find_package(Vulkan REQUIRED)
 set(GLFW_BUILD_EXAMPLES OFF)
 set(GLFW_BUILD_TESTS OFF)
 set(GLFW_BUILD_DOCS OFF)
-
+set(GLFW_VULKAN_STATIC ON CACHE BOOL "Link Vulkan statically with GLFW" FORCE)
 add_subdirectory(external/glfw)
+
 add_subdirectory(external/glm)
 
 # Store source files
@@ -45,11 +49,13 @@ file(GLOB_RECURSE SRC_FILES src/*.cpp)
 
 # Store shader files and define build rules
 find_program(GLSL_VALIDATOR glslangValidator HINTS 
-${Vulkan_GLSLANG_VALIDATOR_EXECUTABLE}
-/usr/bin 
-/usr/local/bin 
-${VULKAN_SDK_PATH}/Bin
-${VULKAN_SDK_PATH}/Bin32
+  ${Vulkan_GLSLANG_VALIDATOR_EXECUTABLE}
+  /usr/bin 
+  /usr/local/bin 
+  ${VULKAN_SDK_PATH}/Bin
+  ${VULKAN_SDK_PATH}/Bin32
+  ${VULKAN_SDK}/Bin
+  ${VULKAN_SDK}/Bin32
 )
 file(GLOB_RECURSE GLSL_SOURCE_FILES
   "${PROJECT_SOURCE_DIR}/shaders/*.frag"
@@ -83,22 +89,31 @@ target_include_directories(${PROJECT_NAME}
   PRIVATE external/glfw/include
   PRIVATE external/glm/include
 )
-  
-target_link_libraries(${PROJECT_NAME}
-  PRIVATE glfw
-  PRIVATE glm
-  PRIVATE Vulkan::Vulkan
-  PRIVATE dl
-  PRIVATE pthread
-  PRIVATE X11
-  PRIVATE Xxf86vm
-  PRIVATE Xrandr
-  PRIVATE Xi
-)
-  
-set_target_properties(${PROJECT_NAME} PROPERTIES 
-  RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR} 
-  OUTPUT_NAME app.bin
-)
+
+# Platform specific
+if(UNIX AND NOT APPLE)  # Linux
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE glfw
+    PRIVATE glm
+    PRIVATE Vulkan::Vulkan
+    PRIVATE dl
+  )
+
+  set_target_properties(${PROJECT_NAME} PROPERTIES 
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR} 
+    OUTPUT_NAME app.bin
+  )
+elseif(WIN32)  # Windows
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE glfw
+    PRIVATE glm
+    PRIVATE Vulkan::Vulkan
+  )
+
+  set_target_properties(${PROJECT_NAME} PROPERTIES 
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR} 
+    OUTPUT_NAME app.exe
+  )
+endif()
 
 add_dependencies(${PROJECT_NAME} ${SHADER_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.22.2)
 
-project(hephaestus VERSION 0.0.0)
+set(NAME hephaestus)
+
+project(${NAME} VERSION 0.0.0)
 
 enable_language(CXX)
 set(CMAKE_CXX_STANDARD 20)
@@ -17,7 +19,12 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 # endif()
 
 set(BUILD_SHARED_LIBS OFF CACHE BOOL "Build shared libraries" FORCE)
-set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static-libgcc -static-libstdc++")
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static-libgcc -static-libstdc++")
+  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -static-libgcc -static-libstdc++")
+elseif(MSVC)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MT")  # Static runtime for MSVC
+endif()
 
 # Download git submodules
 find_package(Git QUIET)
@@ -34,20 +41,39 @@ if(GIT_FOUND AND EXISTS "${PROJECT_SOURCE_DIR}/.git")
   endif()
 endif()
 
-find_package(Vulkan REQUIRED)
+# 1. Set VULKAN_SDK_PATH in .env.cmake to target specific vulkan version
+if (DEFINED VULKAN_SDK_PATH)
+  set(Vulkan_INCLUDE_DIRS "${VULKAN_SDK_PATH}/Include") # 1.1 Make sure this include path is correct
+  set(Vulkan_LIBRARIES "${VULKAN_SDK_PATH}/Lib") # 1.2 Make sure lib path is correct
+  set(Vulkan_FOUND "True")
+else()
+  find_package(Vulkan REQUIRED) # throws error if could not find Vulkan
+  message(STATUS "Found Vulkan: $ENV{VULKAN_SDK}")
+endif()
+if (NOT Vulkan_FOUND)
+	message(FATAL_ERROR "Could not find Vulkan library!")
+else()
+	message(STATUS "Using vulkan lib at: ${Vulkan_LIBRARIES}")
+endif()
 
+# 2. GLFW (static link)
 set(GLFW_BUILD_EXAMPLES OFF)
 set(GLFW_BUILD_TESTS OFF)
 set(GLFW_BUILD_DOCS OFF)
 set(GLFW_VULKAN_STATIC ON CACHE BOOL "Link Vulkan statically with GLFW" FORCE)
 add_subdirectory(external/glfw)
+set(GLFW_INCLUDE_DIRS "${PROJECT_SOURCE_DIR}/external/glfw/include")
+set(GLFW_LIBRARIES glfw)
 
+# 3. GLM (static link)
 add_subdirectory(external/glm)
+set(GLM_INCLUDE_DIRS "${PROJECT_SOURCE_DIR}/external/glm/include")
+set(GLM_LIBRARIES glm)
 
-# Store source files
-file(GLOB_RECURSE SRC_FILES src/*.cpp)
+# 4. Store source files
+file(GLOB_RECURSE SOURCES ${PROJECT_SOURCE_DIR}/src/*.cpp)
 
-# Store shader files and define build rules
+# 5. Store shader files and define build rules
 find_program(GLSL_VALIDATOR glslangValidator HINTS 
   ${Vulkan_GLSLANG_VALIDATOR_EXECUTABLE}
   /usr/bin 
@@ -57,6 +83,10 @@ find_program(GLSL_VALIDATOR glslangValidator HINTS
   ${VULKAN_SDK}/Bin
   ${VULKAN_SDK}/Bin32
 )
+if(NOT GLSL_VALIDATOR)
+  message(FATAL_ERROR "glslangValidator not found. Install Vulkan SDK or provide it in PATH.")
+endif()
+
 file(GLOB_RECURSE GLSL_SOURCE_FILES
   "${PROJECT_SOURCE_DIR}/shaders/*.frag"
   "${PROJECT_SOURCE_DIR}/shaders/*.vert"
@@ -82,38 +112,58 @@ add_custom_target(
 )
 
 # Define Executable
-add_executable(${PROJECT_NAME} app.cpp ${SRC_FILES} ${SPIRV_SHADERS})
-
-target_include_directories(${PROJECT_NAME}
-  PRIVATE src
-  PRIVATE external/glfw/include
-  PRIVATE external/glm/include
-)
 
 # Platform specific
 if(UNIX AND NOT APPLE)  # Linux
-  target_link_libraries(${PROJECT_NAME}
-    PRIVATE glfw
-    PRIVATE glm
-    PRIVATE Vulkan::Vulkan
-    PRIVATE dl
+  message(STATUS "Creating build for linux")
+
+  add_library(${PROJECT_NAME} SHARED ${SOURCES})
+
+  target_include_directories(${PROJECT_NAME} PRIVATE
+    ${PROJECT_SOURCE_DIR}/src
+    ${PROJECT_SOURCE_DIR}/include
+    ${GLFW_INCLUDE_DIRS}
+    ${GLM_INCLUDE_DIRS}
+  )
+
+  target_link_libraries(${PROJECT_NAME} PRIVATE
+    ${GLFW_LIBRARIES}
+    ${GLM_LIBRARIES}
+    ${Vulkan_LIBRARIES}
+    dl
   )
 
   set_target_properties(${PROJECT_NAME} PROPERTIES 
-    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR} 
-    OUTPUT_NAME app.bin
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}
+    LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}
+    OUTPUT_NAME hephaestus
   )
+
+  target_compile_options(${PROJECT_NAME} PRIVATE -fPIC)
 elseif(WIN32)  # Windows
-  target_link_libraries(${PROJECT_NAME}
-    PRIVATE glfw
-    PRIVATE glm
-    PRIVATE Vulkan::Vulkan
+  message(STATUS "Creating build for windows")
+
+  add_executable(${PROJECT_NAME} app.cpp ${SOURCES} ${SPIRV_SHADERS})
+
+  target_include_directories(${PROJECT_NAME} PRIVATE
+    ${PROJECT_SOURCE_DIR}/src
+    ${PROJECT_SOURCE_DIR}/include
+    ${GLFW_INCLUDE_DIRS}
+    ${GLM_INCLUDE_DIRS}
+  )
+
+  target_link_libraries(${PROJECT_NAME} PRIVATE
+    ${GLFW_LIBRARIES}
+    ${GLM_LIBRARIES}
+    ${Vulkan_LIBRARIES}
   )
 
   set_target_properties(${PROJECT_NAME} PROPERTIES 
     RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR} 
-    OUTPUT_NAME app.exe
+    OUTPUT_NAME app
   )
 endif()
 
+target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_17)
+set_property(TARGET ${PROJECT_NAME} PROPERTY VS_DEBUGGER_WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/build")
 add_dependencies(${PROJECT_NAME} ${SHADER_DIR})

--- a/include/hephaestus/engine.hpp
+++ b/include/hephaestus/engine.hpp
@@ -1,13 +1,6 @@
 #pragma once
 
 #include <memory>
-#include <vulkan/vulkan.hpp>
-
-#include "device.hpp"
-#include "events/event.hpp"
-#include "events/key_event.hpp"
-#include "renderer.hpp"
-#include "window.hpp"
 
 namespace hep {
 
@@ -24,14 +17,9 @@ class Engine {
 
   void run();
 
-  void onEvent(KeyReleasedEvent& event);
-
  private:
-  Window window;
-  Device device;
-  Renderer renderer;
-
-  bool isRunning = true;
+  class Impl;
+  std::unique_ptr<Impl> pImpl;
 };
 
 }  // namespace hep

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -1,69 +1,95 @@
-#include "engine.hpp"
+#include "hephaestus/engine.hpp"
 
 #include <chrono>
+#include <memory>
+#include <vulkan/vulkan.hpp>
 
+#include "device.hpp"
+#include "events/event.hpp"
+#include "events/key_event.hpp"
 #include "frame_info.hpp"
 #include "render_system.hpp"
+#include "renderer.hpp"
 #include "util/logger.hpp"
+#include "window.hpp"
 
 namespace hep {
 
-Engine::Engine()
-    : window{WINDOW_WIDTH, WINDOW_HEIGHT},
-      device{this->window},
-      renderer{this->window, this->device} {}
+class Engine::Impl {
+ public:
+  Impl(const Impl&) = delete;
+  Impl& operator=(const Impl&) = delete;
 
-Engine::~Engine() {}
+  Impl()
+      : window{WINDOW_WIDTH, WINDOW_HEIGHT},
+        device{this->window},
+        renderer{this->window, this->device} {}
 
-void Engine::run() {
-  RenderSystem renderSystem{this->device,
-                            this->renderer.getSwapChainRenderPass()};
+  ~Impl() = default;
 
-  auto startTime = std::chrono::high_resolution_clock::now();
-  auto currentTime = startTime;
+  void run() {
+    RenderSystem renderSystem{this->device,
+                              this->renderer.getSwapChainRenderPass()};
 
-  EventSystem::get().addListener<KeyReleasedEvent>(
-      std::bind(&Engine::onEvent, this, std::placeholders::_1));
+    auto startTime = std::chrono::high_resolution_clock::now();
+    auto currentTime = startTime;
 
-  while (this->isRunning && !this->window.shouldClose()) {
-    glfwPollEvents();
+    EventSystem::get().addListener<KeyReleasedEvent>(
+        std::bind(&Impl::onEvent, this, std::placeholders::_1));
 
-    auto newTime = std::chrono::high_resolution_clock::now();
-    double deltaTime =
-        std::chrono::duration<double, std::chrono::seconds::period>(newTime -
-                                                                    currentTime)
-            .count();
-    currentTime = newTime;
+    while (this->isRunning && !this->window.shouldClose()) {
+      glfwPollEvents();
 
-    vk::CommandBuffer commandBuffer = this->renderer.beginFrame();
-    if (commandBuffer != nullptr) {
-      double elapsedTime =
-          std::chrono::duration<double>(currentTime - startTime).count();
+      auto newTime = std::chrono::high_resolution_clock::now();
+      double deltaTime =
+          std::chrono::duration<double, std::chrono::seconds::period>(
+              newTime - currentTime)
+              .count();
+      currentTime = newTime;
 
-      vk::Extent2D extent = this->renderer.getCurrentFramebufferExtent();
-      glm::vec2 extentVec2(static_cast<float>(extent.width),
-                           static_cast<float>(extent.height));
+      vk::CommandBuffer commandBuffer = this->renderer.beginFrame();
+      if (commandBuffer != nullptr) {
+        double elapsedTime =
+            std::chrono::duration<double>(currentTime - startTime).count();
 
-      FrameInfo frameInfo{commandBuffer, this->renderer.getFrameIndex(),
-                          elapsedTime, deltaTime, extentVec2};
+        vk::Extent2D extent = this->renderer.getCurrentFramebufferExtent();
+        glm::vec2 extentVec2(static_cast<float>(extent.width),
+                             static_cast<float>(extent.height));
 
-      this->renderer.beginSwapChainRenderPass(commandBuffer);
+        FrameInfo frameInfo{commandBuffer, this->renderer.getFrameIndex(),
+                            elapsedTime, deltaTime, extentVec2};
 
-      renderSystem.render(commandBuffer, frameInfo);
+        this->renderer.beginSwapChainRenderPass(commandBuffer);
 
-      this->renderer.endSwapChainRenderPass(commandBuffer);
-      this->renderer.endFrame();
+        renderSystem.render(commandBuffer, frameInfo);
+
+        this->renderer.endSwapChainRenderPass(commandBuffer);
+        this->renderer.endFrame();
+      }
+    }
+
+    this->device.waitIdle();
+  }
+
+  void onEvent(KeyReleasedEvent& event) {
+    if (event.getKeyCode() == Key::Escape) {
+      log::info("Escape key pressed. Quiting...");
+      this->isRunning = false;
     }
   }
 
-  this->device.waitIdle();
-}
+ private:
+  Window window;
+  Device device;
+  Renderer renderer;
 
-void Engine::onEvent(KeyReleasedEvent& event) {
-  if (event.getKeyCode() == Key::Escape) {
-    log::info("Escape key pressed. Quiting...");
-    this->isRunning = false;
-  }
-}
+  bool isRunning = true;
+};
+
+Engine::Engine() : pImpl(std::make_unique<Impl>()) {}
+
+Engine::~Engine() = default;
+
+void Engine::run() { this->pImpl->run(); }
 
 }  // namespace hep

--- a/testbed/CMakeLists.txt
+++ b/testbed/CMakeLists.txt
@@ -1,0 +1,70 @@
+cmake_minimum_required(VERSION 3.22.2)
+
+set(NAME testbed)
+project(${NAME})
+
+enable_language(CXX)
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+set(HEPHAESTUS_INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/../include)
+set(HEPHAESTUS_LIBRARIES ${CMAKE_BINARY_DIR}/../build/libhephaestus.so)
+
+add_executable(testbed main.cpp)
+
+target_include_directories(testbed PRIVATE ${HEPHAESTUS_INCLUDE_DIRS})
+
+find_library(HEPHAESTUS_LIB NAMES hephaestus HINTS "${CMAKE_SOURCE_DIR}/../build")
+if(NOT HEPHAESTUS_LIB)
+  message(FATAL_ERROR "libhephaestus.so not found in ../build/lib")
+else()
+  message(STATUS "Found libhephaestus.so")
+endif()
+
+target_link_libraries(testbed PRIVATE ${HEPHAESTUS_LIBRARIES})
+
+set_target_properties(testbed PROPERTIES
+  RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}
+  OUTPUT_NAME testbed.bin
+  BUILD_RPATH "${CMAKE_BINARY_DIR}/lib"
+)
+
+# Below is all the shader stuff
+find_program(GLSL_VALIDATOR glslangValidator HINTS 
+  ${Vulkan_GLSLANG_VALIDATOR_EXECUTABLE}
+  /usr/bin 
+  /usr/local/bin 
+  ${VULKAN_SDK_PATH}/Bin
+  ${VULKAN_SDK_PATH}/Bin32
+  ${VULKAN_SDK}/Bin
+  ${VULKAN_SDK}/Bin32
+)
+if(NOT GLSL_VALIDATOR)
+  message(FATAL_ERROR "glslangValidator not found. Install Vulkan SDK or provide it in PATH.")
+endif()
+
+file(GLOB_RECURSE GLSL_SOURCE_FILES
+  "${PROJECT_SOURCE_DIR}/shaders/*.frag"
+  "${PROJECT_SOURCE_DIR}/shaders/*.vert"
+)
+
+set(SHADER_DIR shaders)
+set(SHADER_OUTPUT_DIR ${CMAKE_BINARY_DIR}/${SHADER_DIR})
+
+foreach(GLSL ${GLSL_SOURCE_FILES})
+  get_filename_component(FILE_NAME ${GLSL} NAME)
+  set(SPIRV "${SHADER_OUTPUT_DIR}/${FILE_NAME}.spv")
+  add_custom_command(
+    OUTPUT ${SPIRV}
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${SHADER_OUTPUT_DIR}
+    COMMAND ${GLSL_VALIDATOR} -V ${GLSL} -o ${SPIRV}
+    DEPENDS ${GLSL})
+  list(APPEND SPIRV_BINARY_FILES ${SPIRV})
+endforeach(GLSL)
+
+add_custom_target(
+  ${SHADER_DIR}
+  DEPENDS ${SPIRV_BINARY_FILES}
+)
+
+add_dependencies(${PROJECT_NAME} ${SHADER_DIR})

--- a/testbed/main.cpp
+++ b/testbed/main.cpp
@@ -1,7 +1,7 @@
 #include <iostream>
 #include <stdexcept>
 
-#include "src/engine.hpp"
+#include "hephaestus/engine.hpp"
 
 int main(int argc, const char** argv) {
   (void)argc;

--- a/testbed/shaders/triangle.frag
+++ b/testbed/shaders/triangle.frag
@@ -1,0 +1,54 @@
+#version 450
+
+layout (location = 0) in vec3 color;
+
+layout (location = 0) out vec4 outColor;
+
+layout (push_constant) uniform Push {
+  mat4 transform;
+  vec4 color;
+  vec4 data;
+} push;
+
+vec3 palette(float t) {
+    vec3 a = vec3(0.5, 0.5, 0.5);
+    vec3 b = vec3(0.5, 0.5, 0.5);
+    vec3 c = vec3(1.0, 1.0, 1.0);
+    vec3 d = vec3(0.263,0.416,0.557);
+
+    return a + b*cos( 6.28318*(c*t+d) );
+}
+
+void main() {
+  float time = push.data.z;
+  
+  vec2 uv = (gl_FragCoord.xy * 2.0 - push.data.xy) / push.data.y;
+  vec2 uv0 = uv;
+  vec3 finalColor = vec3(0.0);
+
+  for(int i = 0; i < 4; i++){
+    uv = fract(uv * 1.2) - 0.5;
+    
+    float d = length(uv) * exp(-length(uv0));
+
+    vec3 col = palette(length(uv0) + i * 0.4 + time * 0.5);
+
+    d = sin(d * 8.0 + time) / 8.0;
+    d = abs(d);
+
+    d = pow(0.01 / d, 2.0);
+  
+    finalColor += col * d;
+  }
+
+  outColor = vec4(finalColor, 1.0);
+
+  // Circle example
+  // float dist = distance(gl_FragCoord.xy, push.data.xy / 2);
+
+  // if (dist < 200) {
+  //   discard;
+  // } else {
+  //   outColor = push.color;
+  // }
+}

--- a/testbed/shaders/triangle.vert
+++ b/testbed/shaders/triangle.vert
@@ -1,0 +1,16 @@
+#version 450
+
+layout (location = 0) in vec2 position;
+layout (location = 1) in vec3 color;
+
+layout (location = 0) out vec3 fragColor;
+
+layout (push_constant) uniform Push {
+  mat4 transform;
+  vec4 color;
+} push;
+
+void main() {
+  gl_Position = vec4(push.transform * vec4(position, 0.0, 1.0));
+  fragColor = color;
+}


### PR DESCRIPTION
resolves #55 

Relates to:

- #56 
- #9

## Context

The game engine builds to a dynamically loaded object. This means users the engine will be more convenient to use in future development. The app no longer will have a "global state", as all user accessible functions are provided via sdk (`include/`).

## Implementation

- Builds for windows (loosely)
- Using pImpl idiom for game engine classes to hide implementation
- Added `include/` that will store all sdk (public interface) related code
- `src/` is strickly backend implementation code that shouldnt be directly accessible
- Added `testbed/` for testing the engine as a user of it

## Testing Instructions

1. Build engine via `mkdir build && cd build && cmake .. && make`
2. Build testbed via `cd testbed/ && cmake . && make`
3. Run testbed via `./testbed`
