### PR TITLE
Index buffers

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -12,17 +12,12 @@ Relates to:
 
 ## Context
 
-**Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
-
-**Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
+TODO
 
 ## Implementation
 
-**Describe the solution you'd like**
-A clear and concise description of what you want to happen.
+TODO
 
 ## Additional resources
 
-Add any other context or screenshots about the feature request here.
+TODO

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,9 +1,5 @@
 resolves TODO
 
-Relates to:
-
-- TODO
-
 ## Context
 
 TODO
@@ -18,6 +14,6 @@ TODO
 
 ## Testing Instructions
 
-1. Build engine via `mkdir build && cd build && cmake .. && make`
+1. Build engine via `cmake . && make`
 2. Build testbed via `cd testbed/ && cmake . && make`
-3. Run testbed via `./testbed`
+3. Run testbed via `cd testbed/ && ./testbed`

--- a/src/basic_render_system.cpp
+++ b/src/basic_render_system.cpp
@@ -9,32 +9,16 @@ BasicRenderSystem::BasicRenderSystem(Device& device, vk::RenderPass renderPass)
   createPipelineLayout();
   createPipeline(renderPass);
 
-  Model::Builder firstTriangleBuilder{};
-  firstTriangleBuilder.vertices = {{{-0.5f, 0.5f}, {1, 0, 0}},
-                                   {{0.5f, 0.5f}, {0, 1, 0}},
-                                   {{0.0f, -0.5f}, {0, 0, 1}}};
+  Model::Builder quadBuilder{};
+  quadBuilder.vertices = {{{-1.0f, -1.0f}, {1, 0, 0}},
+                          {{-1.0f, 1.0f}, {1, 0, 0}},
+                          {{1.0f, 1.0f}, {0, 1, 0}},
+                          {{1.0f, -1.0f}, {0, 0, 1}}};
+  quadBuilder.indicies = {0, 1, 2, 0, 2, 3};
 
-  this->model = std::make_unique<Model>(this->device, firstTriangleBuilder);
+  this->quad = std::make_unique<Model>(this->device, quadBuilder);
 
-  Model::Builder secondTriangleBuilder{};
-  secondTriangleBuilder.vertices = {{{-1.0f, -1.0f}, {1, 0, 0}},
-                                    {{-1.0f, 1.0f}, {0, 1, 0}},
-                                    {{1.0f, 1.0f}, {0, 0, 1}}};
-
-  this->triangle1 =
-      std::make_unique<Model>(this->device, secondTriangleBuilder);
-
-  Model::Builder thirdTriangleBuilder{};
-  thirdTriangleBuilder.vertices = {{{-1.0f, -1.0f}, {1, 0, 0}},
-                                   {{1.0f, 1.0f}, {0, 1, 0}},
-                                   {{1.0f, -1.0f}, {0, 0, 1}}};
-
-  this->triangle2 = std::make_unique<Model>(this->device, thirdTriangleBuilder);
-
-  pushConstant.transform = {{1.0f, 0.0f, 0.0f, 0.0f},
-                            {0.0f, 1.0f, 0.0f, 0.0f},
-                            {0.0f, 0.0f, 1.0f, 0.0f},
-                            {0.0f, 0.0f, 0.0f, 1.0f}};
+  pushConstant.transform = glm::mat4(1.0f);
 }
 
 BasicRenderSystem ::~BasicRenderSystem() {
@@ -50,8 +34,7 @@ void BasicRenderSystem::render(vk::CommandBuffer commandBuffer,
                        frameInfo.currentFramebufferExtent.y,
                        frameInfo.elapsedTime, 0.0f};
 
-  // Triangle 1
-  triangle1->bind(commandBuffer);
+  quad->bind(commandBuffer);
 
   pushConstant.color = {1.0f, 0.0f, 0.0f, 1.0f};
   commandBuffer.pushConstants(
@@ -59,36 +42,7 @@ void BasicRenderSystem::render(vk::CommandBuffer commandBuffer,
       vk::ShaderStageFlagBits::eVertex | vk::ShaderStageFlagBits::eFragment, 0,
       sizeof(PushConstantData), &pushConstant);
 
-  triangle1->draw(commandBuffer);
-
-  // Triangle 2
-  triangle2->bind(commandBuffer);
-
-  pushConstant.color = {0.0f, 1.0f, 0.0f, 1.0f};
-
-  commandBuffer.pushConstants(
-      this->pipelineLayout,
-      vk::ShaderStageFlagBits::eVertex | vk::ShaderStageFlagBits::eFragment, 0,
-      sizeof(PushConstantData), &pushConstant);
-
-  triangle2->draw(commandBuffer);
-
-  // this->model->bind(commandBuffer);
-
-  // frameCount++;
-  // if (frameCount % 1000 == 0) {
-  //   frameCount = 0;
-
-  //   // translation
-  //   pushConstant.transform[3].x += 0.1f;
-  //   pushConstant.transform[3].y += 0.1f;
-  // }
-
-  // commandBuffer.pushConstants(this->pipelineLayout,
-  //                             vk::ShaderStageFlagBits::eVertex, 0,
-  //                             sizeof(PushConstantData), &pushConstant);
-
-  // this->model->draw(commandBuffer);
+  quad->draw(commandBuffer);
 }
 
 void BasicRenderSystem::createPipelineLayout() {

--- a/src/basic_render_system.cpp
+++ b/src/basic_render_system.cpp
@@ -1,28 +1,35 @@
-#include "render_system.hpp"
+#include "basic_render_system.hpp"
 
 #include "util/logger.hpp"
 
 namespace hep {
 
-RenderSystem::RenderSystem(Device& device, vk::RenderPass renderPass)
+BasicRenderSystem::BasicRenderSystem(Device& device, vk::RenderPass renderPass)
     : device{device}, pipeline{device} {
   createPipelineLayout();
   createPipeline(renderPass);
 
-  std::vector<Model::Vertex> vertices{{{-0.5f, 0.5f}, {1, 0, 0}},
-                                      {{0.5f, 0.5f}, {0, 1, 0}},
-                                      {{0.0f, -0.5f}, {0, 0, 1}}};
-  this->model = std::make_unique<Model>(this->device, vertices);
+  Model::Builder firstTriangleBuilder{};
+  firstTriangleBuilder.vertices = {{{-0.5f, 0.5f}, {1, 0, 0}},
+                                   {{0.5f, 0.5f}, {0, 1, 0}},
+                                   {{0.0f, -0.5f}, {0, 0, 1}}};
 
-  std::vector<Model::Vertex> trig1Vertices{{{-1.0f, -1.0f}, {1, 0, 0}},
-                                           {{-1.0f, 1.0f}, {0, 1, 0}},
-                                           {{1.0f, 1.0f}, {0, 0, 1}}};
-  this->triangle1 = std::make_unique<Model>(this->device, trig1Vertices);
+  this->model = std::make_unique<Model>(this->device, firstTriangleBuilder);
 
-  std::vector<Model::Vertex> trig2Vertices{{{-1.0f, -1.0f}, {1, 0, 0}},
-                                           {{1.0f, 1.0f}, {0, 1, 0}},
-                                           {{1.0f, -1.0f}, {0, 0, 1}}};
-  this->triangle2 = std::make_unique<Model>(this->device, trig2Vertices);
+  Model::Builder secondTriangleBuilder{};
+  secondTriangleBuilder.vertices = {{{-1.0f, -1.0f}, {1, 0, 0}},
+                                    {{-1.0f, 1.0f}, {0, 1, 0}},
+                                    {{1.0f, 1.0f}, {0, 0, 1}}};
+
+  this->triangle1 =
+      std::make_unique<Model>(this->device, secondTriangleBuilder);
+
+  Model::Builder thirdTriangleBuilder{};
+  thirdTriangleBuilder.vertices = {{{-1.0f, -1.0f}, {1, 0, 0}},
+                                   {{1.0f, 1.0f}, {0, 1, 0}},
+                                   {{1.0f, -1.0f}, {0, 0, 1}}};
+
+  this->triangle2 = std::make_unique<Model>(this->device, thirdTriangleBuilder);
 
   pushConstant.transform = {{1.0f, 0.0f, 0.0f, 0.0f},
                             {0.0f, 1.0f, 0.0f, 0.0f},
@@ -30,13 +37,13 @@ RenderSystem::RenderSystem(Device& device, vk::RenderPass renderPass)
                             {0.0f, 0.0f, 0.0f, 1.0f}};
 }
 
-RenderSystem ::~RenderSystem() {
+BasicRenderSystem ::~BasicRenderSystem() {
   log::trace("destroyed vk::PipelineLayout");
   this->device.get()->destroyPipelineLayout(this->pipelineLayout);
 }
 
-void RenderSystem::render(vk::CommandBuffer commandBuffer,
-                          FrameInfo frameInfo) {
+void BasicRenderSystem::render(vk::CommandBuffer commandBuffer,
+                               FrameInfo frameInfo) {
   this->pipeline.bind(commandBuffer);
 
   pushConstant.data = {frameInfo.currentFramebufferExtent.x,
@@ -84,7 +91,7 @@ void RenderSystem::render(vk::CommandBuffer commandBuffer,
   // this->model->draw(commandBuffer);
 }
 
-void RenderSystem::createPipelineLayout() {
+void BasicRenderSystem::createPipelineLayout() {
   vk::PushConstantRange pushConstantRange{};
 
   pushConstantRange.stageFlags =
@@ -107,7 +114,7 @@ void RenderSystem::createPipelineLayout() {
   }
 }
 
-void RenderSystem::createPipeline(vk::RenderPass renderPass) {
+void BasicRenderSystem::createPipeline(vk::RenderPass renderPass) {
   assert(pipelineLayout != nullptr &&
          "Cannot create pipeline before pipeline layout");
 

--- a/src/basic_render_system.hpp
+++ b/src/basic_render_system.hpp
@@ -26,13 +26,13 @@ struct PushConstantData {
 
  Currently there isn't enough render systems to make this "worth it"
 */
-class RenderSystem {
+class BasicRenderSystem {
  public:
-  RenderSystem(const RenderSystem&) = delete;
-  RenderSystem& operator=(const RenderSystem&) = delete;
+  BasicRenderSystem(const BasicRenderSystem&) = delete;
+  BasicRenderSystem& operator=(const BasicRenderSystem&) = delete;
 
-  RenderSystem(Device& device, vk::RenderPass renderPass);
-  ~RenderSystem();
+  BasicRenderSystem(Device& device, vk::RenderPass renderPass);
+  ~BasicRenderSystem();
 
   void render(vk::CommandBuffer commandBuffer, FrameInfo frameInfo);
 

--- a/src/basic_render_system.hpp
+++ b/src/basic_render_system.hpp
@@ -47,10 +47,8 @@ class BasicRenderSystem {
   Device& device;
   Pipeline pipeline;
   vk::PipelineLayout pipelineLayout;
-  std::unique_ptr<Model> model;
 
-  std::unique_ptr<Model> triangle1;
-  std::unique_ptr<Model> triangle2;
+  std::unique_ptr<Model> quad;
 };
 
 }  // namespace hep

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -8,11 +8,11 @@
 #include <memory>
 #include <vulkan/vulkan.hpp>
 
+#include "basic_render_system.hpp"
 #include "device.hpp"
 #include "events/event.hpp"
 #include "events/key_event.hpp"
 #include "frame_info.hpp"
-#include "render_system.hpp"
 #include "renderer.hpp"
 #include "ui/ui_system.hpp"
 #include "util/logger.hpp"
@@ -41,8 +41,8 @@ class Engine::Impl {
   };
 
   void run() {
-    RenderSystem renderSystem{this->device,
-                              this->renderer.getSwapChainRenderPass()};
+    BasicRenderSystem basicRenderSystem{
+        this->device, this->renderer.getSwapChainRenderPass()};
 
     auto startTime = std::chrono::high_resolution_clock::now();
     auto currentTime = startTime;
@@ -113,7 +113,7 @@ class Engine::Impl {
         this->renderer.beginSwapChainRenderPass(commandBuffer);
 
         // Render systems
-        renderSystem.render(commandBuffer, frameInfo);
+        basicRenderSystem.render(commandBuffer, frameInfo);
         ui.render(commandBuffer);
 
         this->renderer.endSwapChainRenderPass(commandBuffer);

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -32,9 +32,9 @@ Model::Vertex::getAttributeDescriptions() {
   return attributeDescriptions;
 }
 
-Model::Model(Device& device, const std::vector<Vertex>& vertices)
-    : device{device} {
-  createVertexBuffers(vertices);
+Model::Model(Device& device, const Builder& builder) : device{device} {
+  createVertexBuffers(builder.vertices);
+  createIndexBuffers(builder.indicies);
 }
 
 Model::~Model() {
@@ -43,16 +43,32 @@ Model::~Model() {
 
   this->device.get()->freeMemory(this->vertexBufferMemory);
   log::trace("freed memory for vertexBuffer");
+
+  if (this->hasIndexBuffer) {
+    this->device.get()->destroyBuffer(this->indexBuffer);
+    log::trace("destroyed indexBuffer");
+
+    this->device.get()->freeMemory(this->indexBufferMemory);
+    log::trace("freed memory for indexBuffer");
+  }
 }
 
 void Model::bind(vk::CommandBuffer commandBuffer) {
   vk::Buffer buffers[] = {this->vertexBuffer};
   vk::DeviceSize offset[] = {0};
   commandBuffer.bindVertexBuffers(0, 1, buffers, offset);
+
+  if (this->hasIndexBuffer) {
+    commandBuffer.bindIndexBuffer(this->indexBuffer, 0, vk::IndexType::eUint32);
+  }
 }
 
 void Model::draw(vk::CommandBuffer commandBuffer) {
-  commandBuffer.draw(this->vertexCount, 1, 0, 0);
+  if (this->hasIndexBuffer) {
+    commandBuffer.drawIndexed(this->indexCount, 1, 0, 0, 0);
+  } else {
+    commandBuffer.draw(this->vertexCount, 1, 0, 0);
+  }
 }
 
 void Model::createVertexBuffers(const std::vector<Vertex>& vertices) {
@@ -82,6 +98,40 @@ void Model::createVertexBuffers(const std::vector<Vertex>& vertices) {
                             this->vertexBuffer, this->vertexBufferMemory);
 
   this->device.copyBuffer(stagingBuffer, this->vertexBuffer, bufferSize);
+
+  this->device.get()->destroyBuffer(stagingBuffer);
+  this->device.get()->freeMemory(stagingBufferMemory);
+}
+
+void Model::createIndexBuffers(const std::vector<u32>& indicies) {
+  this->indexCount = static_cast<u32>(indicies.size());
+  this->hasIndexBuffer = this->indexCount > 0;
+
+  if (!this->hasIndexBuffer) { return; }
+
+  vk::DeviceSize bufferSize = sizeof(indicies[0]) * this->indexCount;
+
+  vk::Buffer stagingBuffer;
+  vk::DeviceMemory stagingBufferMemory;
+
+  this->device.createBuffer(bufferSize, vk::BufferUsageFlagBits::eTransferSrc,
+                            vk::MemoryPropertyFlagBits::eHostVisible |
+                                vk::MemoryPropertyFlagBits::eHostCoherent,
+                            stagingBuffer, stagingBufferMemory);
+
+  void* data =
+      this->device.get()->mapMemory(stagingBufferMemory, 0, bufferSize);
+  memcpy(data, indicies.data(), static_cast<size_t>(bufferSize));
+  this->device.get()->unmapMemory(stagingBufferMemory);
+
+  this->device.createBuffer(bufferSize,
+                            vk::BufferUsageFlagBits::eTransferDst |
+                                vk::BufferUsageFlagBits::eIndexBuffer,
+                            vk::MemoryPropertyFlagBits::eHostVisible |
+                                vk::MemoryPropertyFlagBits::eHostCoherent,
+                            this->indexBuffer, this->indexBufferMemory);
+
+  this->device.copyBuffer(stagingBuffer, this->indexBuffer, bufferSize);
 
   this->device.get()->destroyBuffer(stagingBuffer);
   this->device.get()->freeMemory(stagingBufferMemory);

--- a/src/model.hpp
+++ b/src/model.hpp
@@ -29,10 +29,23 @@ class Model {
     // }
   };
 
+  /**
+   * Helper struct
+   *
+   * Temporarily stores vertices and indicies of a model before it
+   * can be moved into the model's vertex buffer and index buffer respectively
+   *
+   * TODO: move this documentation elsewhere (doc/ ?)
+   */
+  struct Builder {
+    std::vector<Vertex> vertices{};
+    std::vector<u32> indicies{};
+  };
+
   Model(const Model&) = delete;
   Model& operator=(const Model&) = delete;
 
-  Model(Device& device, const std::vector<Vertex>& vertices);
+  Model(Device& device, const Builder& builder);
   ~Model();
 
   void bind(vk::CommandBuffer commandBuffer);
@@ -40,12 +53,18 @@ class Model {
 
  private:
   void createVertexBuffers(const std::vector<Vertex>& vertices);
+  void createIndexBuffers(const std::vector<u32>& indicies);
 
   Device& device;
 
   vk::Buffer vertexBuffer;
   vk::DeviceMemory vertexBufferMemory;
   u32 vertexCount;
+
+  bool hasIndexBuffer = false;
+  vk::Buffer indexBuffer;
+  vk::DeviceMemory indexBufferMemory;
+  u32 indexCount;
 };
 
 }  // namespace hep

--- a/src/swapchain.cpp
+++ b/src/swapchain.cpp
@@ -404,7 +404,7 @@ vk::SurfaceFormatKHR Swapchain::chooseSurfaceFormat(
   }
 
   for (const auto& availableFormat : availableFormats) {
-    if (availableFormat.format == vk::Format::eB8G8R8A8Srgb &&
+    if (availableFormat.format == vk::Format::eB8G8R8A8Unorm &&
         availableFormat.colorSpace == vk::ColorSpaceKHR::eSrgbNonlinear) {
       return availableFormat;
     }


### PR DESCRIPTION
resolves #50 

## Implementation

- utilizing index buffers to create a quad with 4 verticies instead of a quad with 6 verticies
- fixed imgui window coloing issue

## Screenshots

![2025-03-18_23-32](https://github.com/user-attachments/assets/1a7adf42-abb4-4cd1-9dfd-6c5ef75df439)
***figure 1** imgui windows correct coloring*

## Testing Instructions

1. Build engine via `mkdir build && cd build && cmake .. && make`
2. Build testbed via `cd testbed/ && cmake . && make`
3. Run testbed via `./testbed`
